### PR TITLE
Change to janestreet ocamlformat style

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
-profile = default
+profile = janestreet
+sequence-blank-line = preserve-one

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3,15 +3,15 @@
 open Whatwhat
 
 let () =
-  begin
-    print_endline "Downloading schedule from Forecast...";
-    let theSchedule = Forecast.getTheCurrentSchedule () in
-    print_endline "Obtained:";
-    Printf.printf "%d projects; %d people; and %d assingments\n"
+  print_endline "Downloading schedule from Forecast...";
+  let theSchedule = Forecast.getTheCurrentSchedule () in
+  print_endline "Obtained:";
+  Printf.printf
+    "%d projects; %d people; and %d assingments\n"
     (Forecast.IntMap.cardinal theSchedule.projects)
     (Forecast.StringMap.cardinal theSchedule.people)
     (List.length theSchedule.assignments);
-    let issues = GithubRaw.get_project_issues "NowWhat Test Project" in
-    print_endline "Obtained issues:";
-    List.iter (fun c -> print_endline @@ GithubRaw.show_issue c) issues
-  end
+  let issues = GithubRaw.get_project_issues "NowWhat Test Project" in
+  print_endline "Obtained issues:";
+  List.iter (fun c -> print_endline @@ GithubRaw.show_issue c) issues
+;;

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -2,23 +2,24 @@
     
     Looks first in the XDG config location*)
 
-type t = { githubToken : string; forecastId : string; forecastToken : string }
+type t =
+  { githubToken : string
+  ; forecastId : string
+  ; forecastToken : string
+  }
 
 let loadConfig () : t =
   let json =
-    XDGBaseDir.default.config_home ^ "/nowwhat/secrets.json"
-    |> Yojson.Basic.from_file
+    XDGBaseDir.default.config_home ^ "/nowwhat/secrets.json" |> Yojson.Basic.from_file
   in
 
   match json with
   | `Assoc
-      [
-        ("githubToken", `String githubToken);
-        ("forecastId", `String forecastId);
-        ("forecastToken", `String forecastToken);
-      ] ->
-      { githubToken; forecastId; forecastToken }
-  | _ ->
-      failwith @@ "Could not decode config file\n" ^ Yojson.Basic.to_string json
+      [ ("githubToken", `String githubToken)
+      ; ("forecastId", `String forecastId)
+      ; ("forecastToken", `String forecastToken)
+      ] -> { githubToken; forecastId; forecastToken }
+  | _ -> failwith @@ "Could not decode config file\n" ^ Yojson.Basic.to_string json
+;;
 
 let settings = loadConfig ()

--- a/lib/forecast.ml
+++ b/lib/forecast.ml
@@ -12,36 +12,32 @@
  *)
 
 open CalendarLib
-
 module Raw = ForecastRaw
-
-module IntMap = Map.Make(Int)        (* Issue number => project *)
-module StringMap = Map.Make(String)  (* email => person *)
+module IntMap = Map.Make (Int) (* Issue number => project *)
+module StringMap = Map.Make (String) (* email => person *)
 
 type project =
-  { number    : int;    (* Ought to be a GitHub issue number *)
-    name      : string;
-    programme : string;
+  { number : int (* Ought to be a GitHub issue number *)
+  ; name : string
+  ; programme : string
   }
 
 type person =
-  { email       : string;
-    first_name  : string;
-    last_name   : string;
+  { email : string
+  ; first_name : string
+  ; last_name : string
   }
 
-type assignment = {
-    project      : int;           (* The project code *)
-    person       : string;        (* An email *)
-    finance_code : string option;
-    (* TODO: And an allocation ... *)
+type assignment =
+  { project : int (* The project code *)
+  ; person : string (* An email *)
+  ; finance_code : string option (* TODO: And an allocation ... *)
   }
 
 type schedule =
-  {
-    projects    : project IntMap.t;
-    people      : person StringMap.t;
-    assignments : assignment list;
+  { projects : project IntMap.t
+  ; people : person StringMap.t
+  ; assignments : assignment list
   }
 
 (* ------------------------------------------------------------ *)
@@ -51,59 +47,54 @@ type schedule =
    https://v2.ocaml.org/manual/bindingops.html *)
 let ( let+ ) o f = Option.map f o
 
-
-
-
 (* ------------------------------------------------------------ *)
 (* Logging for errors and warnings *)
 
 (* TODO: Change this to add the notifications to a stack *)
 
-type logType = LogError | LogWarning 
+type logType =
+  | LogError
+  | LogWarning
 
 let log_raw_project (what : logType) (p : Raw.project) msg =
   match what with
   | LogWarning ->
-     print_endline @@ "Warning: " ^ msg ^ " for project id=" ^ (string_of_int p.id)
-  | LogError ->
-     print_endline @@ "Error: " ^ msg ^ " for project id=" ^ (string_of_int p.id)
+    print_endline @@ "Warning: " ^ msg ^ " for project id=" ^ string_of_int p.id
+  | LogError -> print_endline @@ "Error: " ^ msg ^ " for project id=" ^ string_of_int p.id
+;;
 
 let log_project (what : logType) (p : project) msg =
-   let make_hut23_code n = " [hut23-" ^ (string_of_int n) ^ "]" in 
-   match what with
-   | LogWarning ->
-      print_endline @@ "Warning: " ^ msg ^ " for project " ^ (make_hut23_code p.number)
-   | LogError ->
-      print_endline @@ "Error: " ^ msg ^ " for project " ^ (make_hut23_code p.number)
+  let make_hut23_code n = " [hut23-" ^ string_of_int n ^ "]" in
+  match what with
+  | LogWarning ->
+    print_endline @@ "Warning: " ^ msg ^ " for project " ^ make_hut23_code p.number
+  | LogError ->
+    print_endline @@ "Error: " ^ msg ^ " for project " ^ make_hut23_code p.number
+;;
 
 let log_raw_person (what : logType) (p : Raw.person) msg =
   let name = p.first_name ^ " " ^ p.last_name in
   match what with
-  | LogWarning ->
-     print_endline @@ "Warning: " ^ msg ^ " for " ^ name
-  | LogError ->
-     print_endline @@ "Error: " ^ msg ^ " for " ^ name
+  | LogWarning -> print_endline @@ "Warning: " ^ msg ^ " for " ^ name
+  | LogError -> print_endline @@ "Error: " ^ msg ^ " for " ^ name
+;;
 
 let log_assignment (what : logType) (a : Raw.assignment) msg =
-  let aid (a : Raw.assignment) = "(" ^ (string_of_int a.id) ^ ")" in
+  let aid (a : Raw.assignment) = "(" ^ string_of_int a.id ^ ")" in
   match what with
-  | LogWarning ->
-     print_endline @@ "Warning: " ^ msg ^ (aid a)
-  | LogError ->
-     print_endline @@ "Error: " ^ msg ^ (aid a)
+  | LogWarning -> print_endline @@ "Warning: " ^ msg ^ aid a
+  | LogError -> print_endline @@ "Error: " ^ msg ^ aid a
+;;
 
 (* ------------------------------------------------------------ *)
 (* domain-specific data *)
 
 (* Regex to match the `NNN` in `hut23-NNN` *)
-let hut23_code_re = 
-     Re.compile Re.(seq [start; str "hut23-"; group (rep1 digit); stop])
+let hut23_code_re = Re.compile Re.(seq [ start; str "hut23-"; group (rep1 digit); stop ])
 
 (* The Forecast internal id of a single, hard-coded project in Forecast called
-   "Time off", which we do not use *) 
-let timeoff_project_id = 1684536 
-
-
+   "Time off", which we do not use *)
+let timeoff_project_id = 1684536
 
 (* ------------------------------------------------------------ *)
 (* Utilities for extracting data from particular fields and entities *)
@@ -111,55 +102,56 @@ let timeoff_project_id = 1684536
 let extract_finance_code _ (project : Raw.project) =
   match project.tags with
   | [] ->
-     log_raw_project LogWarning project "Missing Finance Code";
-     None
-  | fc :: [] ->
-     Some fc
+    log_raw_project LogWarning project "Missing Finance Code";
+    None
+  | fc :: [] -> Some fc
   | fc :: _ ->
-     log_raw_project LogWarning project "More than one potential Finance code (using the first tag)";
-     Some fc
+    log_raw_project
+      LogWarning
+      project
+      "More than one potential Finance code (using the first tag)";
+    Some fc
+;;
 
 let extract_project_number (project : Raw.project) =
   let cd = project.code in
-  try 
-    Some (Option.get cd                      (* Raises Invalid_argument *) 
-          |> Re.exec hut23_code_re           (* Raises Not_found *)
-          |> (fun gp -> Re.Group.get gp 1)      (* Raises Not_found *)
-          |> int_of_string)
-  with 
+  try
+    Some
+      (Option.get cd (* Raises Invalid_argument *)
+      |> Re.exec hut23_code_re (* Raises Not_found *)
+      |> (fun gp -> Re.Group.get gp 1) (* Raises Not_found *)
+      |> int_of_string)
+  with
   | Invalid_argument _ ->
-       log_raw_project LogError project "Missing project code";
-       None
+    log_raw_project LogError project "Missing project code";
+    None
   | Not_found ->
-     log_raw_project LogError project "Malformed project code";
-     None
-
+    log_raw_project LogError project "Malformed project code";
+    None
+;;
 
 (* ------------------------------------------------------------ *)
 
 let validate_project (clients : Raw.client Raw.IdMap.t) id (p : Raw.project) =
-  if (p.archived || id = timeoff_project_id) then
-    None
-  else 
-    let nmbr   = extract_project_number p in
+  if p.archived || id = timeoff_project_id
+  then None
+  else (
+    let nmbr = extract_project_number p in
     let client = Raw.IdMap.find (Option.get p.client_id) clients in
-    let+ nmbr in {number    = nmbr;
-                  name      = p.name;
-                  programme = client.name}
+    let+ nmbr = nmbr in
+    { number = nmbr; name = p.name; programme = client.name })
+;;
 
 let validate_person _ (p : Raw.person) =
-  if p.archived then
-    None
-  else
+  if p.archived
+  then None
+  else (
     match p.email with
     | None ->
-       log_raw_person LogError p "Missing email";
-       None
-    | Some email ->
-       Some { email = email;
-              first_name = p.first_name;
-              last_name = p.last_name
-         }
+      log_raw_person LogError p "Missing email";
+      None
+    | Some email -> Some { email; first_name = p.first_name; last_name = p.last_name })
+;;
 
 (* if StringMap.mem email m then *)
 (*     begin *)
@@ -172,72 +164,73 @@ let validate_person _ (p : Raw.person) =
 (* Raw.IdMap.to_seq people *)
 (* |> Seq.fold_left add_person StringMap.empty  *)
 
-
 let validate_assignment fcs people projects (a : Raw.assignment) =
   match a.person_id with
-  (* If there is no person_id, this assignment is to a Placeholder and we ignore it *) 
-  | None -> None  
+  (* If there is no person_id, this assignment is to a Placeholder and we ignore it *)
+  | None -> None
   | Some person_id ->
-     match (IntMap.find_opt person_id people) with
+    (match IntMap.find_opt person_id people with
      (* We may have deleted the corresponding person or project already because they were invalid *)
      | None ->
-        log_assignment LogError a "Deleting an assignment because of missing person";
-        None
+       log_assignment LogError a "Deleting an assignment because of missing person";
+       None
      | Some person ->
-        match (IntMap.find_opt a.project_id projects) with
+       (match IntMap.find_opt a.project_id projects with
         | None ->
-           log_assignment LogError a "Deleting as assignment because of a missing project";
-           None
+          log_assignment LogError a "Deleting as assignment because of a missing project";
+          None
         | Some project ->
-           Some { project      = project.number;
-                  person       = person.email;
-                  finance_code = Raw.IdMap.find_opt a.project_id fcs;
-             }
+          Some
+            { project = project.number
+            ; person = person.email
+            ; finance_code = Raw.IdMap.find_opt a.project_id fcs
+            }))
+;;
 
 (* ------------------------------------------------------------ *)
 
 (* Make map email => person *)
 let make_people_map people_id =
-  people_id
-  |> IntMap.to_seq
-  |> Seq.map (fun (_, p) -> (p.email, p))
-  |> StringMap.of_seq
+  people_id |> IntMap.to_seq |> Seq.map (fun (_, p) -> p.email, p) |> StringMap.of_seq
+;;
 
 (* Make map number => project, with the slight complication that there may be
    two projects with the same issue number *)
 let make_project_map projects_id =
   let add_project m (_, (p : project)) =
-    match (IntMap.find_opt p.number m) with
-    | None ->
-       IntMap.add p.number p m
+    match IntMap.find_opt p.number m with
+    | None -> IntMap.add p.number p m
     | Some existing_p ->
-       if p.name <> existing_p.name then
-         log_project LogWarning p "A project with the same number as this has a different name";
-       m 
+      if p.name <> existing_p.name
+      then
+        log_project
+          LogWarning
+          p
+          "A project with the same number as this has a different name";
+      m
   in
   Seq.fold_left add_project IntMap.empty (IntMap.to_seq projects_id)
-
-
+;;
 
 (* ------------------------------------------------------------ *)
 (* Interface *)
 
-
 let getTheSchedule (startDate : Date.t) (endDate : Date.t) =
   let clnts, peopl, _, projs, asnts = Raw.getTheSchedule startDate endDate in
 
-  (* A things_id is a map from forecast ids to the thing *) 
+  (* A things_id is a map from forecast ids to the thing *)
   let fcs_id = Raw.IdMap.filter_map extract_finance_code projs in
-  
+
   let projects_id = IntMap.filter_map (validate_project clnts) projs in
-  let people_id   = IntMap.filter_map validate_person peopl in
-  let assignments = List.filter_map (validate_assignment fcs_id people_id projects_id) asnts in
+  let people_id = IntMap.filter_map validate_person peopl in
+  let assignments =
+    List.filter_map (validate_assignment fcs_id people_id projects_id) asnts
+  in
 
   let projects = make_project_map projects_id in
-  let people   = make_people_map people_id in
-  
+  let people = make_people_map people_id in
+
   { projects; people; assignments }
+;;
 
-
-let getTheCurrentSchedule () =
-  getTheSchedule (Date.today ()) (Date.today ())
+let getTheCurrentSchedule () = getTheSchedule (Date.today ()) (Date.today ())

--- a/lib/forecast.mli
+++ b/lib/forecast.mli
@@ -1,34 +1,33 @@
 (** High-level interface to Forecast. Returns only entities that are correctly
     defined accoring to our domain model. *)
 
-open CalendarLib 
-
+open CalendarLib
 module IntMap : module type of Map.Make (Int)
 module StringMap : module type of Map.Make (String)
 
-type project = {
-    number : int;
-    name : string;
-    programme : string;
+type project =
+  { number : int
+  ; name : string
+  ; programme : string
   }
 
-type person = {
-    email : string;
-    first_name : string;
-    last_name : string;
+type person =
+  { email : string
+  ; first_name : string
+  ; last_name : string
   }
 
-type assignment = {
-  project : int;
-  person : string;
-  finance_code : string option;
-}
+type assignment =
+  { project : int
+  ; person : string
+  ; finance_code : string option
+  }
 
-type schedule = {
-  projects : project IntMap.t;
-  people : person StringMap.t;
-  assignments : assignment list;
-}
+type schedule =
+  { projects : project IntMap.t
+  ; people : person StringMap.t
+  ; assignments : assignment list
+  }
 
 val getTheSchedule : Date.t -> Date.t -> schedule
 val getTheCurrentSchedule : unit -> schedule

--- a/lib/forecastRaw.ml
+++ b/lib/forecastRaw.ml
@@ -6,131 +6,126 @@ open Yojson.Basic.Util
 open CalendarLib
 
 (* An IdMap is a map from Forecast ids *)
-module IdMap = Map.Make(Int)
+module IdMap = Map.Make (Int)
 
 let forecastRequest ?(query = []) endpoint =
   let _, body =
     let headers =
       Header.of_list
-        [
-          ("Forecast-Account-ID", Config.settings.forecastId);
-          ("Authorization", "Bearer " ^ Config.settings.forecastToken);
+        [ "Forecast-Account-ID", Config.settings.forecastId
+        ; "Authorization", "Bearer " ^ Config.settings.forecastToken
         ]
     and uri =
-      Uri.with_query'
-        (Uri.of_string ("https://api.forecastapp.com/" ^ endpoint))
-        query
+      Uri.with_query' (Uri.of_string ("https://api.forecastapp.com/" ^ endpoint)) query
     in
     Client.get ~headers uri |> Lwt_main.run
   in
   Basic.from_string (Lwt_main.run @@ Body.to_string body)
   |> member endpoint (* Forecast returns, eg, {"clients", [...]} *)
+;;
 
 (* ---------------------------------------------------------------------- *)
 
-type project = {
-  id : int;
-  harvest_id : int option;
-  client_id : int option; (* The built-in project has no client !! *)
-  name : string;
-  code : string option;
-  tags : string list;
-  notes : string option;
-  archived : bool;
+type project =
+  { id : int
+  ; harvest_id : int option
+  ; client_id : int option (* The built-in project has no client !! *)
+  ; name : string
+  ; code : string option
+  ; tags : string list
+  ; notes : string option
+  ; archived : bool
   }
-                 [@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
+[@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
 
 let getProjects () =
-  forecastRequest "projects" |> to_list
+  forecastRequest "projects"
+  |> to_list
   |> List.map (fun x -> project_of_yojson (x : Basic.t :> Safe.t))
+;;
 
 (* ---------------------------------------------------------------------- *)
 
-type client = {
-    id : int;
-    name : string;
-    archived : bool
+type client =
+  { id : int
+  ; name : string
+  ; archived : bool
   }
-                [@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
+[@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
 
 let getClients () =
-  forecastRequest "clients" |> to_list
+  forecastRequest "clients"
+  |> to_list
   |> List.map (fun x -> client_of_yojson (x : Basic.t :> Safe.t))
+;;
 
 (* ---------------------------------------------------------------------- *)
 
-type person = {
-    id : int;
-    first_name : string;
-    last_name : string;
-    email : string option;
-    login : string;
-    roles : string list;
-    archived : bool;
+type person =
+  { id : int
+  ; first_name : string
+  ; last_name : string
+  ; email : string option
+  ; login : string
+  ; roles : string list
+  ; archived : bool
   }
-                [@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
+[@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
 
 let getPeople () =
-  forecastRequest "people" |> to_list
+  forecastRequest "people"
+  |> to_list
   |> List.map (fun x -> person_of_yojson (x : Basic.t :> Safe.t))
+;;
 
 (* ---------------------------------------------------------------------- *)
 
-type placeholder = {
-    id : int;
-    name : string;
-    roles : string list;
-    archived : bool;
+type placeholder =
+  { id : int
+  ; name : string
+  ; roles : string list
+  ; archived : bool
   }
-                     [@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
+[@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
 
 let getPlaceholders () =
   forecastRequest "placeholders"
   |> to_list
   |> List.map (fun x -> placeholder_of_yojson (x : Basic.t :> Safe.t))
+;;
 
 (* ---------------------------------------------------------------------- *)
 
-type assignment = {
-    id : int;
-    project_id : int;
-    person_id : int option;
-    placeholder_id : int option;
-    start_date : string;
-    end_date : string;
-    allocation : int;
-    notes : string option;
+type assignment =
+  { id : int
+  ; project_id : int
+  ; person_id : int option
+  ; placeholder_id : int option
+  ; start_date : string
+  ; end_date : string
+  ; allocation : int
+  ; notes : string option
   }
-                    [@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
+[@@deriving show, of_yojson] [@@yojson.allow_extra_fields]
 
 let getAssignments (startDate : Date.t) (endDate : Date.t) =
   assert (Date.Period.nb_days (Date.sub endDate startDate) >= 0);
 
   let st = Printer.DatePrinter.to_string startDate
   and ed = Printer.DatePrinter.to_string endDate in
-  forecastRequest "assignments" ~query:[ ("start_date", st); ("end_date", ed) ]
+  forecastRequest "assignments" ~query:[ "start_date", st; "end_date", ed ]
   |> to_list
   |> List.map (fun x -> assignment_of_yojson (x : Basic.t :> Safe.t))
-
+;;
 
 (* ---------------------------------------------------------------------- *)
 
 (* TODO: Have these run concurrently *)
 let getTheSchedule (startDate : Date.t) (endDate : Date.t) =
-  let make_map identify xs =
-    List.map identify xs
-    |> List.to_seq
-    |> IdMap.of_seq
-  in
-  (
-    getClients () |>
-      make_map (function ({id; _} as c : client) -> (id, c)),
-    getPeople () |> 
-      make_map (function ({id; _} as p : person) -> (id, p)),
-    getPlaceholders () |>
-      make_map (function ({id; _} as p : placeholder) -> (id, p)),
-    getProjects () |>
-      make_map (function ({id; _} as p : project) -> (id, p)),
-    getAssignments startDate endDate
-  )
-
+  let make_map identify xs = List.map identify xs |> List.to_seq |> IdMap.of_seq in
+  ( getClients () |> make_map (function ({ id; _ } as c : client) -> id, c)
+  , getPeople () |> make_map (function ({ id; _ } as p : person) -> id, p)
+  , getPlaceholders () |> make_map (function ({ id; _ } as p : placeholder) -> id, p)
+  , getProjects () |> make_map (function ({ id; _ } as p : project) -> id, p)
+  , getAssignments startDate endDate )
+;;

--- a/lib/forecastRaw.mli
+++ b/lib/forecastRaw.mli
@@ -2,49 +2,52 @@
     form returned by Forecast. *)
 
 open CalendarLib
-
 module IdMap : module type of Map.Make (Int)
 
-type client = { id : int; name : string; archived : bool }
+type client =
+  { id : int
+  ; name : string
+  ; archived : bool
+  }
 
-type project = {
-  id : int;
-  harvest_id : int option;
-  client_id : int option;
-  name : string;
-  code : string option;
-  tags : string list;
-  notes : string option;
-  archived : bool;
-}
+type project =
+  { id : int
+  ; harvest_id : int option
+  ; client_id : int option
+  ; name : string
+  ; code : string option
+  ; tags : string list
+  ; notes : string option
+  ; archived : bool
+  }
 
-type person = {
-  id : int;
-  first_name : string;
-  last_name : string;
-  email : string option;
-  login : string;
-  roles : string list;
-  archived : bool;
-}
+type person =
+  { id : int
+  ; first_name : string
+  ; last_name : string
+  ; email : string option
+  ; login : string
+  ; roles : string list
+  ; archived : bool
+  }
 
-type placeholder = {
-  id : int;
-  name : string;
-  roles : string list;
-  archived : bool;
-}
+type placeholder =
+  { id : int
+  ; name : string
+  ; roles : string list
+  ; archived : bool
+  }
 
-type assignment = {
-  id : int;
-  project_id : int;
-  person_id : int option;
-  placeholder_id : int option;
-  start_date : string;
-  end_date : string;
-  allocation : int;
-  notes : string option;
-}
+type assignment =
+  { id : int
+  ; project_id : int
+  ; person_id : int option
+  ; placeholder_id : int option
+  ; start_date : string
+  ; end_date : string
+  ; allocation : int
+  ; notes : string option
+  }
 
 val getClients : unit -> client list
 val show_client : client -> string
@@ -55,7 +58,6 @@ val show_person : person -> string
 val getPlaceholders : unit -> placeholder list
 val show_placeholder : placeholder -> string
 
-val getAssignments : Date.t -> Date.t -> assignment list
 (** Return all assignments wich overlap a given date range. The range is from
     [startDate] to [endDate], inclusive, and all overlapping assignments are 
     returned in full. (In particular, any given returned [assignment] 
@@ -63,7 +65,15 @@ val getAssignments : Date.t -> Date.t -> assignment list
 
     The end date may not be more than 180 days after start date.
  *)
+val getAssignments : Date.t -> Date.t -> assignment list
 
 val show_assignment : assignment -> string
 
-val getTheSchedule : Date.t -> Date.t -> client IdMap.t * person IdMap.t * placeholder IdMap.t * project IdMap.t * assignment list
+val getTheSchedule
+  :  Date.t
+  -> Date.t
+  -> client IdMap.t
+     * person IdMap.t
+     * placeholder IdMap.t
+     * project IdMap.t
+     * assignment list

--- a/lib/githubRaw.ml
+++ b/lib/githubRaw.ml
@@ -8,27 +8,35 @@ open Yojson
 
 exception HttpError of string
 
-type person = { login : string; name : string option; email : string option }
+type person =
+  { login : string
+  ; name : string option
+  ; email : string option
+  }
 [@@deriving show]
 
-type issue = {
-  number : int;
-  title : string;
-  body : string;
-  state : string;
-  assignees : person list;
-  reactions : (string * person) list;
-}
+type issue =
+  { number : int
+  ; title : string
+  ; body : string
+  ; state : string
+  ; assignees : person list
+  ; reactions : (string * person) list
+  }
 [@@deriving show]
 
-type column = {
-  name : string;
-  cards : (issue * string) list;
+type column =
+  { name : string
+  ; cards : (issue * string) list
       (* The string is a cursor, would be nice to have a type alias for it. *)
-}
+  }
 [@@deriving show]
 
-type project = { number : int; name : string; columns : column list }
+type project =
+  { number : int
+  ; name : string
+  ; columns : column list
+  }
 [@@deriving show]
 
 type project_root = { projects : project list } [@@deriving show]
@@ -39,56 +47,71 @@ type project_root = { projects : project list } [@@deriving show]
 let member = Basic.Util.member
 
 let person_of_json json =
-  {
-    login = json |> member "login" |> Basic.Util.to_string;
-    name = Some (json |> member "name" |> Basic.Util.to_string);
-    email = Some (json |> member "email" |> Basic.Util.to_string);
+  { login = json |> member "login" |> Basic.Util.to_string
+  ; name = Some (json |> member "name" |> Basic.Util.to_string)
+  ; email = Some (json |> member "email" |> Basic.Util.to_string)
   }
+;;
 
 let issue_of_json json =
-  json |> member "node" |> member "content" |> fun x ->
-  {
-    number = x |> member "number" |> Basic.Util.to_int;
-    title = x |> member "title" |> Basic.Util.to_string;
-    body = x |> member "body" |> Basic.Util.to_string;
-    state = x |> member "state" |> Basic.Util.to_string;
-    assignees =
-      x |> member "assignees" |> member "edges"
-      |> Basic.Util.convert_each (fun y -> y |> member "node" |> person_of_json);
-    reactions =
-      x |> member "reactions" |> member "edges"
+  json
+  |> member "node"
+  |> member "content"
+  |> fun x ->
+  { number = x |> member "number" |> Basic.Util.to_int
+  ; title = x |> member "title" |> Basic.Util.to_string
+  ; body = x |> member "body" |> Basic.Util.to_string
+  ; state = x |> member "state" |> Basic.Util.to_string
+  ; assignees =
+      x
+      |> member "assignees"
+      |> member "edges"
+      |> Basic.Util.convert_each (fun y -> y |> member "node" |> person_of_json)
+  ; reactions =
+      x
+      |> member "reactions"
+      |> member "edges"
       |> Basic.Util.convert_each (fun y ->
-             ( y |> member "node" |> member "content" |> Basic.Util.to_string,
-               y |> member "node" |> member "user" |> person_of_json ));
+           ( y |> member "node" |> member "content" |> Basic.Util.to_string
+           , y |> member "node" |> member "user" |> person_of_json ))
   }
+;;
 
 let column_of_json json =
-  json |> member "node" |> fun x ->
-  {
-    name = x |> member "name" |> Basic.Util.to_string;
-    cards =
-      x |> member "cards" |> member "edges"
+  json
+  |> member "node"
+  |> fun x ->
+  { name = x |> member "name" |> Basic.Util.to_string
+  ; cards =
+      x
+      |> member "cards"
+      |> member "edges"
       |> Basic.Util.convert_each (fun y ->
-             (issue_of_json y, y |> member "cursor" |> Basic.Util.to_string));
+           issue_of_json y, y |> member "cursor" |> Basic.Util.to_string)
   }
+;;
 
 let project_of_json json =
-  json |> member "node" |> fun x ->
-  {
-    number = x |> member "number" |> Basic.Util.to_int;
-    name = x |> member "name" |> Basic.Util.to_string;
-    columns =
-      x |> member "columns" |> member "edges"
-      |> Basic.Util.convert_each column_of_json;
+  json
+  |> member "node"
+  |> fun x ->
+  { number = x |> member "number" |> Basic.Util.to_int
+  ; name = x |> member "name" |> Basic.Util.to_string
+  ; columns =
+      x |> member "columns" |> member "edges" |> Basic.Util.convert_each column_of_json
   }
+;;
 
 let project_root_of_json json =
-  {
-    projects =
-      json |> member "data" |> member "repository" |> member "projects"
+  { projects =
+      json
+      |> member "data"
+      |> member "repository"
+      |> member "projects"
       |> member "edges"
-      |> Basic.Util.convert_each project_of_json;
+      |> Basic.Util.convert_each project_of_json
   }
+;;
 
 (* ---------------------------------------------------------------------- *)
 (* QUERYING GITHUB *)
@@ -101,13 +124,15 @@ let github_graph_ql_endpoint = "https://api.github.com/graphql"
 let run_github_query (git_hub_token : string) body =
   let auth_cred = Auth.credential_of_string ("Bearer " ^ git_hub_token) in
   let header =
-    Header.init () |> fun header ->
-    Header.add_authorization header auth_cred |> fun header ->
-    Header.prepend_user_agent header "NowWhat"
+    Header.init ()
+    |> fun header ->
+    Header.add_authorization header auth_cred
+    |> fun header -> Header.prepend_user_agent header "NowWhat"
   in
   let body_obj = Cohttp_lwt.Body.of_string body in
   let uri = Uri.of_string github_graph_ql_endpoint in
   Client.post ~headers:header ~body:body_obj uri
+;;
 
 (* For formatting the JSON query to enable correct parsing on Github's side *)
 let remove_line_breaks (q : string) = Str.global_replace (Str.regexp "\n") "" q
@@ -121,6 +146,7 @@ let read_file_as_string filepath =
   let return_string = channel |> BatIO.lines_of |> BatEnum.fold ( ^ ) "" in
   let () = close_in channel in
   return_string
+;;
 
 (* The Github API query's JSON body is built by taking a template and replacing
    some placeholders with the project board name and cursor for paging. *)
@@ -139,6 +165,7 @@ let build_query project_name cursor =
   let to_replace = Str.regexp "PROJECTNAME" in
   let replace_with = "\\\"" ^ project_name ^ "\\\"" in
   Str.global_replace to_replace replace_with cursor_query |> remove_line_breaks
+;;
 
 (* This is the main function of this module, that would be called externally.
 
@@ -147,29 +174,34 @@ let build_query project_name cursor =
 let get_project_issues (project_name : string) =
   let github_token = Config.settings.githubToken in
 
-  let rec get_project_issues_page (project_name : string) cursor
-      (acc : (issue * string) list) =
+  let rec get_project_issues_page
+    (project_name : string)
+    cursor
+    (acc : (issue * string) list)
+    =
     let query = build_query project_name cursor in
     let response, body = run_github_query github_token query |> Lwt_main.run in
     let () =
-      if
-        not @@ Code.is_success @@ Code.code_of_status
-        @@ Response.status response
-      then
+      if not @@ Code.is_success @@ Code.code_of_status @@ Response.status response
+      then (
         let code_string = Code.string_of_status @@ Response.status response in
         let error_msg = "Github query failed with HTTP error " ^ code_string in
-        raise @@ HttpError error_msg
+        raise @@ HttpError error_msg)
     in
 
     (* Parse the response into a list of issues. *)
     let issues =
-      body |> Cohttp_lwt.Body.to_string |> Lwt_main.run |> Basic.from_string
+      body
+      |> Cohttp_lwt.Body.to_string
+      |> Lwt_main.run
+      |> Basic.from_string
       |> project_root_of_json
     in
 
     (* TODO Why only the head? Might there be more projects? *)
     let issue_data =
-      issues.projects |> List.hd
+      issues.projects
+      |> List.hd
       |> (fun x -> x.columns)
       |> List.map (fun column -> column.cards)
       |> List.concat
@@ -178,7 +210,8 @@ let get_project_issues (project_name : string) =
     (* Cursor points to the last item returned, used for paging of the requests
      *)
     let next_cursor =
-      if List.length issue_data = 0 then None
+      if List.length issue_data = 0
+      then None
       else issue_data |> List.last |> fun (_, c) -> Some c
     in
 
@@ -191,3 +224,4 @@ let get_project_issues (project_name : string) =
 
   let all_issues = get_project_issues_page project_name None [] in
   List.map fst all_issues
+;;

--- a/lib/githubRaw.mli
+++ b/lib/githubRaw.mli
@@ -1,16 +1,29 @@
-type person = { login : string; name : string option; email : string option }
+type person =
+  { login : string
+  ; name : string option
+  ; email : string option
+  }
 
-type issue = {
-  number : int;
-  title : string;
-  body : string;
-  state : string;
-  assignees : person list;
-  reactions : (string * person) list;
-}
+type issue =
+  { number : int
+  ; title : string
+  ; body : string
+  ; state : string
+  ; assignees : person list
+  ; reactions : (string * person) list
+  }
 
-type column = { name : string; cards : (issue * string) list }
-type project = { number : int; name : string; columns : column list }
+type column =
+  { name : string
+  ; cards : (issue * string) list
+  }
+
+type project =
+  { number : int
+  ; name : string
+  ; columns : column list
+  }
+
 type project_root = { projects : project list }
 
 val show_issue : issue -> string

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -1,4 +1,8 @@
-type what = Panic | Error | Warn | Info
+type what =
+  | Panic
+  | Error
+  | Warn
+  | Info
 
 (* TODO: While we get going, just print to stdout. *)
 type destination = Console
@@ -6,20 +10,13 @@ type destination = Console
 let string_of_what = function
   | Panic -> "Panic"
   | Error -> "Error"
-  | Warn  -> "Warn"
-  | Info  -> "Info"
+  | Warn -> "Warn"
+  | Info -> "Info"
+;;
 
-let defaultLogger _ lvl msg =
-  Printf.printf "Whatwhat: %5s: %s" (string_of_what lvl) msg
-
+let defaultLogger _ lvl msg = Printf.printf "Whatwhat: %5s: %s" (string_of_what lvl) msg
 let theLogger = ref defaultLogger
 
 (* "Every problem in computer science can be solved through another layer of
    indirection" *)
-let log (dst : destination) (lvl : what) (msg : string) : unit =
-  !theLogger dst lvl msg
-
-
-            
-            
-  
+let log (dst : destination) (lvl : what) (msg : string) : unit = !theLogger dst lvl msg

--- a/lib/log.mli
+++ b/lib/log.mli
@@ -12,7 +12,12 @@
 
 *)
 
-type what = Panic | Error | Warn | Info
+type what =
+  | Panic
+  | Error
+  | Warn
+  | Info
+
 type destination = Console
 
 val log : destination -> what -> string -> unit


### PR DESCRIPTION
The diff look monstrous, but all I've done here is changed .ocamlformat:
```
-profile = default
+profile = janestreet
+sequence-blank-line = preserve-one
```
and run `dune fmt`.

I disliked how the default ocamlformat style profile was very shy with linebreaks. So I tried the other profiles on offer, and found that the `janestreet` one was much happier to break lines to my liking. It also removed a lot of empty lines I had added to break the code into blocks for clarity, so I added the `sequence-blank-line` setting to disable that feature. Some example changes where I prefer the new style:

This ugly multiline list of arguments is now one argument per line:
```
-  let rec get_project_issues_page (project_name : string) cursor
-      (acc : (issue * string) list) =
+  let rec get_project_issues_page
+    (project_name : string)
+    cursor
+    (acc : (issue * string) list)
+    =
```
This confusing mixture of having and not having linebreaks between `|>` pipes now has linebreaks between all of them:
```
-  {
-    projects =
-      json |> member "data" |> member "repository" |> member "projects"
-      |> member "edges"
-      |> Basic.Util.convert_each project_of_json;
-  }
+  { projects =
+      json
+      |> member "data"
+      |> member "repository"
+      |> member "projects"
+      |> member "edges"
+      |> Basic.Util.convert_each project_of_json
+  }
```

Most of the other changes this brings I'm ambivalent about, so feel free to propose other ocamlformat settings you'd like to change. I could also try to look for a minimal way to add extra settings to the default profile to achieve what I want, if you in general prefer the default one to janestreet.