### PR TITLE
Parse more data from Github issues

### DIFF
--- a/lib/githubRaw.mli
+++ b/lib/githubRaw.mli
@@ -1,4 +1,14 @@
-type issue = { number : int; title : string; body : string; state : string }
+type person = { login : string; name : string option; email : string option }
+
+type issue = {
+  number : int;
+  title : string;
+  body : string;
+  state : string;
+  assignees : person list;
+  reactions : (string * person) list;
+}
+
 type column = { name : string; cards : (issue * string) list }
 type project = { number : int; name : string; columns : column list }
 type project_root = { projects : project list }

--- a/queries/issues-by-project-graphql.graphql
+++ b/queries/issues-by-project-graphql.graphql
@@ -25,6 +25,27 @@
                             url
                             body
                             state
+                            assignees(first: 100) {
+                                edges {
+                                    node {
+                                        login
+                                        name
+                                        email
+                                    }
+                                }
+                            }
+                            reactions(first: 100) {
+                                edges {
+                                    node {
+                                        content
+                                        user {
+                                            login
+                                            name
+                                            email
+                                        }
+                                    }
+                                }
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
Me and @callummole pair programmed our way into having githubRaw output include issue emojis and assignees. Leaving this as a draft request because we may still want to add parsing of the metadata block at the top before merging.

At least partially addresses https://github.com/alan-turing-institute/whatwhat/issues/1