### PR TITLE
Make config tolerant of missing values, and read secrets from envvars

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -1,28 +1,77 @@
-(** Obtain API secrets from config file
-    
-    Looks first in the XDG config location*)
-
 type t =
-  { github_token : string
-  ; githubbot_token : string
-  ; forecast_id : string
-  ; forecast_token : string
-  ; slack_token : string
+  { github_token : string option
+  ; githubbot_token : string option
+  ; forecast_id : string option
+  ; forecast_token : string option
+  ; slack_token : string option
   }
 
-let loadConfig () : t =
-  let json =
-    XDGBaseDir.default.config_home ^ "/nowwhat/secrets.json" |> Yojson.Basic.from_file
-  in
-  match json with
-  | `Assoc
-      [ ("githubToken", `String github_token)
-      ; ("githubBotToken", `String githubbot_token)
-      ; ("forecastId", `String forecast_id)
-      ; ("forecastToken", `String forecast_token)
-      ; ("slackToken", `String slack_token)
-      ] -> { github_token; githubbot_token; forecast_id; forecast_token; slack_token }
-  | _ -> failwith @@ "Could not decode config file\n" ^ Yojson.Basic.to_string json
+exception MissingSecret of string
+
+let secrets_path = XDGBaseDir.default.config_home ^ "/nowwhat/secrets.json"
+
+(* Read the field called [key] from [json] as a [string option]. *)
+let read_string_opt_field key json =
+  Yojson.Basic.Util.member key json |> Yojson.Basic.Util.to_string_option
 ;;
 
-let settings = loadConfig ()
+(* Find the value for a secret called [key].
+
+   If the environment variable called [String.uppercase_ascii ("WHATWHAT_" ^ key)]
+   exists, return its value. If it doesn't, return the corresponding key from the secrets
+   file. If that doesn't exist either, return [None]. *)
+let find_secret key json_opt =
+  let file_value = Option.bind json_opt @@ read_string_opt_field key in
+  let envvar_key = String.uppercase_ascii ("WHATWHAT_" ^ key) in
+  let envvar_value = Sys.getenv_opt envvar_key in
+  match file_value, envvar_value with
+  | _, Some value -> Some value
+  | Some value, None -> Some value
+  | None, None -> None
+;;
+
+let load_config () : t =
+  let json_opt =
+    try Some (Yojson.Basic.from_file secrets_path) with
+    | Sys_error _ -> None
+  in
+  { github_token = find_secret "githubToken" json_opt
+  ; githubbot_token = find_secret "githubBotToken" json_opt
+  ; forecast_id = find_secret "forecastId" json_opt
+  ; forecast_token = find_secret "forecastToken" json_opt
+  ; slack_token = find_secret "slackToken" json_opt
+  }
+;;
+
+let settings = load_config ()
+
+(* TODO Isn't there some metaprogramming way to autogenerate these? Preprocessing? *)
+let get_github_token () =
+  match settings.github_token with
+  | Some value -> value
+  | None -> raise (MissingSecret "github_token")
+;;
+
+let get_githubbot_token () =
+  match settings.githubbot_token with
+  | Some value -> value
+  | None -> raise (MissingSecret "githubbot_token")
+;;
+
+let get_forecast_id () =
+  match settings.forecast_id with
+  | Some value -> value
+  | None -> raise (MissingSecret "forecast_id")
+;;
+
+let get_forecast_token () =
+  match settings.forecast_token with
+  | Some value -> value
+  | None -> raise (MissingSecret "forecast_token")
+;;
+
+let get_slack_token () =
+  match settings.slack_token with
+  | Some value -> value
+  | None -> raise (MissingSecret "github_bot_token")
+;;

--- a/lib/forecastRaw.ml
+++ b/lib/forecastRaw.ml
@@ -12,8 +12,8 @@ let forecast_request ?(query = []) endpoint =
   let _, body =
     let headers =
       Header.of_list
-        [ "Forecast-Account-ID", Config.settings.forecast_id
-        ; "Authorization", "Bearer " ^ Config.settings.forecast_token
+        [ "Forecast-Account-ID", Config.get_forecast_id ()
+        ; "Authorization", "Bearer " ^ Config.get_forecast_token ()
         ]
     and uri =
       Uri.with_query' (Uri.of_string ("https://api.forecastapp.com/" ^ endpoint)) query

--- a/lib/githubBot.ml
+++ b/lib/githubBot.ml
@@ -10,7 +10,7 @@ let github_post repo issue post_body =
     let headers =
       Header.of_list
         [ "Accept", "application/vnd.github+json"
-        ; "Authorization", "Bearer " ^ Config.settings.githubbot_token
+        ; "Authorization", "Bearer " ^ Config.get_githubbot_token ()
         ]
     and uri =
       Uri.of_string

--- a/lib/githubRaw.ml
+++ b/lib/githubRaw.ml
@@ -203,7 +203,7 @@ let build_issue_query project_name cursor =
 (* These are the main functions of this module, that would be called externally. *)
 
 let get_users () =
-  let github_token = Config.settings.github_token in
+  let github_token = Config.get_github_token () in
   let user_query = read_file_as_string user_query_template_path in
   let body_json = run_github_query github_token user_query in
   let users =
@@ -255,7 +255,7 @@ let rec get_project_issues_page
 (* The external-facing function for getting issues, with arguments needed for recursion
    hidden away in get_project_issues_page. *)
 let get_project_issues (project_name : string) =
-  let github_token = Config.settings.github_token in
+  let github_token = Config.get_github_token () in
   let all_issues = get_project_issues_page project_name github_token None [] in
   List.map fst all_issues
 ;;

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -5,7 +5,7 @@ module Basic = Yojson.Basic
 exception SlackAPIError of string
 
 let slack_post_message_url = "https://slack.com/api/chat.postMessage"
-let slack_token = Config.settings.slack_token
+let slack_token = Config.get_slack_token ()
 let slack_channel = "C0465E3FEN4" (* The #hut23-whatwhat-bot-test channel *)
 
 let header =


### PR DESCRIPTION
Config now tries to get the secrets from two sources: the secrets file, and environment variables with names like `WHATWHAT_GITHUBTOKEN`. If both are present, the environment variable takes effect. It also only errors once you actually try to get the value of a secret, rather than failing right away at load time. So for instance if you don't use the `Slack` module, you won't need a Slack token in your secrets/envvars.