### PR TITLE
Issue duplication fix

### DIFF
--- a/lib/githubRaw.ml
+++ b/lib/githubRaw.ml
@@ -257,8 +257,7 @@ let rec get_project_issues_page
     issues.projects
     |> List.hd
     |> (fun x -> x.columns)
-    |> List.map (fun column -> column.cards)
-    |> List.concat
+    |> List.concat_map (fun column -> column.cards)
   in
   let new_acc = acc @ issue_data in
 


### PR DESCRIPTION
GithubRaw no longer pulls in duplicate issues. The fix I implemented isn't the most elegant one, but it's not _that_ fragile.

Resolves https://github.com/alan-turing-institute/whatwhat/issues/33
